### PR TITLE
bump slevomat/cs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1",
         "consistence/coding-standard": "^3.8",
         "nette/utils": "^2.3@dev || ^3.0@dev",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "^5.0.4",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "require-dev": {


### PR DESCRIPTION
They fixed unused variable warning for this code:
```php
$_ENV = $_GET = $_POST = [];
```

Which is used in many kdyby packages tests/bootstrap.php
https://github.com/Kdyby/Events/blob/1b5ec06/tests/KdybyTests/bootstrap.php#L41
https://github.com/Kdyby/Doctrine/blob/f680c3b/tests/KdybyTests/bootstrap.php#L29
...